### PR TITLE
Add indic-nlp-library in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=['morfessor', 'boilerpipe3', 'tldextract', 'click',
-                      'scrapy', 'tqdm', 'pandas', 'scrapyd', 'nltk', 'scrapyd-client'],  # Optional
+                      'scrapy', 'tqdm', 'pandas', 'scrapyd', 'nltk', 'scrapyd-client', 'indic-nlp-library'],  # Optional
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=['morfessor', 'boilerpipe3', 'tldextract', 'click',
-                      'scrapy', 'tqdm', 'pandas', 'scrapyd', 'nltk', 'scrapyd-client', 'indic-nlp-library'],  # Optional
+                      'scrapy', 'tqdm', 'pandas', 'scrapyd', 'nltk',
+                      'scrapyd-client', 'indic-nlp-library'],  # Optional
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.


### PR DESCRIPTION
`indic-nlp-library` is required to run the scrapper but it is not included in setup.